### PR TITLE
Potential issue in freeglut/src/fg_init.c: Unchecked return from initialization function

### DIFF
--- a/freeglut/src/fg_init.c
+++ b/freeglut/src/fg_init.c
@@ -115,7 +115,7 @@ void fghParseCommandLineArguments ( int* pargc, char** argv, char **pDisplayName
 
         if( fps )
         {
-            int interval;
+            int interval = 0;
             sscanf( fps, "%d", &interval );
 
             if( interval <= 0 )


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

**1 instance** of this defect were found in the following locations:

---
**Instance 1**
File : `freeglut/src/fg_init.c` 
Enclosing Function : `fghParseCommandLineArguments`
Function : `sscanf` 
https://github.com/sagarpant1/liquidfun/blob/7f20402173fd143a3988c921bc384459c6a858f2/freeglut/src/fg_init.c#L119
**Issue in**: _interval_

**Code extract**:

```cpp
        if( fps )
        {
            int interval;
            sscanf( fps, "%d", &interval ); <------ HERE

            if( interval <= 0 )
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
